### PR TITLE
Bevy 0.17

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [".github/", "assets/"]
 # ---------------------------------------------------------------------------- #
 
 [dependencies]
-bevy = { version = "0.17", default-features = false, features = [
+bevy = { version = "0.17.0", default-features = false, features = [
     "bevy_render",
     "bevy_window",
 ] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ smallvec = { version = "1.11.0", features = ["union"] }
 
 
 [dev-dependencies]
-bevy = { version = "0.17", default-features = false, features = [
+bevy = { version = "0.17.0", default-features = false, features = [
     "std",
     "async_executor",
     "bevy_anti_alias",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,26 +32,13 @@ smallvec = { version = "1.11.0", features = ["union"] }
 bevy = { version = "0.17.0", default-features = false, features = [
     "std",
     "async_executor",
-    "bevy_anti_alias",
-    "bevy_camera",
-    "bevy_color",
-    "bevy_core_pipeline",
-    "bevy_input_focus",
     "bevy_log",
-    "bevy_post_process",
-    "bevy_render",
-    "bevy_sprite",
-    "bevy_sprite_render",
-    "bevy_state",
-    "bevy_text",
     "bevy_ui",
     "bevy_ui_render",
     "bevy_winit",
     "default_font",
     "png",
-    "bevy_sprite",
     "x11",
-    "wayland"
 ] }
 
 # ---------------------------------------------------------------------------- #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,12 +32,26 @@ smallvec = { version = "1.11.0", features = ["union"] }
 bevy = { version = "0.17", default-features = false, features = [
     "std",
     "async_executor",
+    "bevy_anti_alias",
+    "bevy_camera",
+    "bevy_color",
+    "bevy_core_pipeline",
+    "bevy_input_focus",
     "bevy_log",
+    "bevy_post_process",
+    "bevy_render",
+    "bevy_sprite",
+    "bevy_sprite_render",
+    "bevy_state",
+    "bevy_text",
     "bevy_ui",
+    "bevy_ui_render",
     "bevy_winit",
     "default_font",
     "png",
+    "bevy_sprite",
     "x11",
+    "wayland"
 ] }
 
 # ---------------------------------------------------------------------------- #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ exclude = [".github/", "assets/"]
 # ---------------------------------------------------------------------------- #
 
 [dependencies]
-bevy = { version = "0.16.0", default-features = false, features = [
+bevy = { version = "0.17", default-features = false, features = [
     "bevy_render",
     "bevy_window",
 ] }
@@ -29,7 +29,7 @@ smallvec = { version = "1.11.0", features = ["union"] }
 
 
 [dev-dependencies]
-bevy = { version = "0.16.0", default-features = false, features = [
+bevy = { version = "0.17", default-features = false, features = [
     "std",
     "async_executor",
     "bevy_log",

--- a/examples/multiple_windows.rs
+++ b/examples/multiple_windows.rs
@@ -1,12 +1,12 @@
 //! An example using two windows with multiple camera per window.
 
+use bevy::camera::{RenderTarget, Viewport};
 use bevy::color::palettes;
 use bevy::prelude::*;
-use bevy::render::camera::{RenderTarget, Viewport};
 use bevy::window::{ExitCondition, WindowRef, WindowResized};
 use bevy_cursor::prelude::*;
 
-const WINDOW_SIZE: Vec2 = Vec2::new(600.0, 400.0);
+const WINDOW_SIZE: UVec2 = UVec2::new(600, 400);
 
 fn main() {
     App::new()
@@ -195,7 +195,7 @@ fn setup(mut commands: Commands) {
 /// Update the viewport of the cameras on the secondary window when this one is resized.
 fn set_camera_viewports(
     secondary_window_q: Query<&Window, With<SecondaryWindow>>,
-    mut resize_events: EventReader<WindowResized>,
+    mut resize_events: MessageReader<WindowResized>,
     mut left_camera_q: Query<&mut Camera, (With<LeftCamera>, Without<RightCamera>)>,
     mut right_camera_q: Query<&mut Camera, With<RightCamera>>,
 ) -> Result {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,9 +23,9 @@
 //! [entity id]: https://docs.rs/bevy/0.16.0/bevy/ecs/entity/struct.Entity.html
 //! [ray]: https://docs.rs/bevy/0.16.0/bevy/math/struct.Ray3d.html
 
+use bevy::camera::RenderTarget;
 use bevy::ecs::query::Has;
 use bevy::prelude::*;
-use bevy::render::camera::RenderTarget;
 use bevy::window::{PrimaryWindow, WindowRef};
 use smallvec::SmallVec;
 
@@ -229,7 +229,9 @@ fn update_cursor_location_res(
             .filter(|&(_, _, camera)| match camera.target {
                 RenderTarget::Window(WindowRef::Primary) => is_primary,
                 RenderTarget::Window(WindowRef::Entity(target_ref)) => target_ref == win_ref,
-                RenderTarget::Image(_) | RenderTarget::TextureView(_) => false,
+                RenderTarget::Image(_)
+                | RenderTarget::TextureView(_)
+                | RenderTarget::None { .. } => false,
             })
             // PERF: this is unlikely to have more than 4 cameras on the same window.
             .collect::<SmallVec<[_; 4]>>();


### PR DESCRIPTION
Update to support Bevy 0.17, pretty self explanatory. Not many changes were needed, camera got relocated to just bevy::camera and `RenderTarget` has a new non-window source. Also fixed the example, which didn't have proper features enabled.

Only contentious part is that I changed the manifest to not specify the patch version so that cargo can resolve the latest patch version itself.